### PR TITLE
Subscribe and disconnect changes.

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -40,7 +40,7 @@ server.listen(61614);
 stompServer.subscribe("/**", function(msg, headers) {
   var topic = headers.destination;
   console.log(topic, "->", msg);
-});
+}, headers);
 
 stompServer.send('/test', {}, 'testMsg');
 ```
@@ -76,7 +76,7 @@ stompServer.send('/test', {}, 'testMsg');
 * [StompServer](#StompServer) ⇐ <code>EventEmitter</code>
     * [new StompServer(config)](#new_StompServer_new)
     * [.onUnsubscribe()](#StompServer+onUnsubscribe) ⇒ <code>boolean</code>
-    * [.subscribe(topic, [callback])](#StompServer+subscribe) ⇒ <code>string</code>
+    * [.subscribe(topic, [callback], headers)](#StompServer+subscribe) ⇒ <code>string</code>
     * [.unsubscribe(id)](#StompServer+unsubscribe) ⇒ <code>boolean</code>
     * [.send(topic, headers, body)](#StompServer+send)
     * [.frameSerializer(frame)](#StompServer+frameSerializer) ⇒ <code>[MsgFrame](#MsgFrame)</code>
@@ -103,7 +103,7 @@ stompServer.send('/test', {}, 'testMsg');
 **Kind**: instance method of <code>[StompServer](#StompServer)</code>  
 <a name="StompServer+subscribe"></a>
 
-### stompServer.subscribe(topic, [callback]) ⇒ <code>string</code>
+### stompServer.subscribe(topic, [callback], headers) ⇒ <code>string</code>
 Subsribe topic
 
 **Kind**: instance method of <code>[StompServer](#StompServer)</code>  
@@ -113,10 +113,11 @@ Subsribe topic
 | --- | --- | --- |
 | topic | <code>string</code> | Subscribed destination, wildcard is supported |
 | [callback] | <code>[OnSubscribedMessageCallback](#OnSubscribedMessageCallback)</code> | Callback function |
+| headers | <code>object</code> | Optional headers, used by client to provide a subscription ID (headers.id) |
 
 **Example**  
 ```js
-stompServer.subscribe("/test.data", function(msg, headers) {});
+stompServer.subscribe("/test.data", function(msg, headers) {}, headers);
 //or alternative
 var subs_id = stompServer.subscribe("/test.data");
 stompServer.on(subs_id, function(msg, headers) {});

--- a/lib/frame.js
+++ b/lib/frame.js
@@ -12,13 +12,13 @@ function Frame(args) {
     if (want_receipt) {
       var _receipt = '';
       receipt_stamp = Math.floor(Math.random() * 99999999999).toString();
-      if (this.headers['session'] != undefined) {
-        _receipt = receipt_stamp + "-" + this.headers['session'];
+      if (this.headers.session !== undefined) {
+        _receipt = receipt_stamp + "-" + this.headers.session;
       }
       else {
         _receipt = receipt_stamp;
       }
-      this.headers['receipt'] = _receipt;
+      this.headers.receipt = _receipt;
     }
     return this;
   };
@@ -44,8 +44,7 @@ function Frame(args) {
     frame += '\x00';
 
     return frame;
-  }
-};
-
+  };
+}
 
 module.exports = Frame;

--- a/lib/stomp.js
+++ b/lib/stomp.js
@@ -31,7 +31,9 @@ function parseHeaders(raw_headers) {
       headers[key] = header.join(':').trim();
       continue;
     }
-    headers[header[0].trim()] = header[1].trim();
+    if (header[1]) {
+      headers[header[0].trim()] = header[1].trim();
+    }
   }
   return headers;
 }
@@ -152,7 +154,7 @@ function FrameHandler(stompServer) {
   this.UNSUBSCRIBE = function (socket, frame) {
     var id = frame.headers.id;
     if (!stompServer.onUnsubscribe(socket, id)) {
-      ServerFrame.ERROR(socket, "SUBSCRIBE ERROR", id);
+      ServerFrame.ERROR(socket, "UNSUBSCRIBE ERROR", id);
     }
   };
   this.SEND = function (socket, frame) {

--- a/lib/stomp.js
+++ b/lib/stomp.js
@@ -49,14 +49,14 @@ function trimNull(a) {
 var StompUtils = {
   genId: genId,
   tokenizeDestination: function (dest) {
-    return dest.substr(dest.indexOf('/') + 1).split(".")
+    return dest.substr(dest.indexOf('/') + 1).split(".");
   },
   sendCommand: function (socket, command, headers, body, want_receipt) {
-    if (headers == undefined) {
+    if (headers === undefined) {
       headers = {};
     }
     if (want_receipt === true) {
-      headers['receipt'] = genId("r");
+      headers.receipt = genId("r");
     }
     var frame = new Frame({
       'command': command,
@@ -68,7 +68,7 @@ var StompUtils = {
   },
   sendFrame: sendFrame,
   parseFrame: function (chunk) {
-    if (chunk == undefined) {
+    if (chunk === undefined) {
       return null;
     }
 
@@ -81,7 +81,7 @@ var StompUtils = {
     var body = the_rest.slice(1, the_rest.length);
 
     if ('content-length' in headers) {
-      headers['bytes_message'] = true;
+      headers.bytes_message = true;
     }
 
     return new Frame({
@@ -108,7 +108,7 @@ var ServerFrame = {
     StompUtils.sendCommand(socket, "RECEIPT", {'receipt-id': receipt});
   },
   ERROR: function (socket, message, description) {
-    var len = description != undefined ? description.length : 0;
+    var len = description !== undefined ? description.length : 0;
     var headers = {
       message: message,
       "content-type": "text/plain",

--- a/package.json
+++ b/package.json
@@ -23,10 +23,10 @@
   },
   "homepage": "https://github.com/4ib3r/StompBrokerJS#readme",
   "dependencies": {
-    "ws": "^1.1.1"
+    "ws": "^3.1.0"
   },
   "devDependencies": {
-    "chai": "^3.5.0",
+    "chai": "^4.1.2",
     "mocha": "^3.2.0",
     "stompjs": "^2.3.3"
   }

--- a/stompServer.js
+++ b/stompServer.js
@@ -101,7 +101,6 @@ var StompServer = function (config) {
    * @property {string} dest Destination
    * @property {string} frame Message frame
    * */
-
   this.onSend = function (socket, args, callback) {
     var bodyObj = args.frame.body;
     var frame = this.frameSerializer(args.frame);
@@ -121,6 +120,20 @@ var StompServer = function (config) {
     }
     args.frame = frame;
     this.emit('send', {frame: {headers: frame.headers, body: bodyObj}, dest: args.dest});
+    this._sendToSubscriptions(socket, frame);
+    if (callback) {
+      callback(true);
+    }
+  };
+
+  /**
+   * Send message to matching subscribers.
+   *
+   * @param {object} websocket to send the message on
+   * @param {string} frame message frame
+   * @private
+   */
+  this._sendToSubscriptions = function (socket, frame) {
     for (var i in this.subscribes) {
       var sub = this.subscribes[i];
       if (socket.sessionId === sub.sessionId) {
@@ -150,10 +163,7 @@ var StompServer = function (config) {
         }
       }
     }
-    if (callback) {
-      callback(true);
-    }
-  };
+  }
 
   /**
    * Client subscribe event, emitted when client subscribe topic
@@ -321,7 +331,7 @@ var StompServer = function (config) {
     if (frame.body !== undefined && frame.headers['content-type'] === 'application/json') {
       frame.body = JSON.parse(frame.body);
     }
-    return frame
+    return frame;
   };
 
   function parseRequest(socket, data) {

--- a/stompServer.js
+++ b/stompServer.js
@@ -159,7 +159,7 @@ var StompServer = function (config) {
         if (sock !== undefined) {
           stomp.StompUtils.sendFrame(sock, args.frame);
         } else {
-          this.emit(sub.id, bodyObj, args.frame.headers);
+          this.emit(sub.id, args.frame.body, args.frame.headers);
         }
       }
     }

--- a/stompServer.js
+++ b/stompServer.js
@@ -139,19 +139,7 @@ var StompServer = function (config) {
       if (socket.sessionId === sub.sessionId) {
         continue;
       }
-      //console.log(args.dest);
-      var tokens = stomp.StompUtils.tokenizeDestination(args.dest);
-      var match = true;
-      for (var t in tokens) {
-        var token = tokens[t];
-        if (sub.tokens[t] === undefined ||
-          (sub.tokens[t] !== token && sub.tokens[t] !== '*' && sub.tokens[t] !== '**')) {
-          match = false;
-          break;
-        } else if (sub.tokens[t] === "**") {
-          break;
-        }
-      }
+      var match = this._checkSubMatchDest(sub, args)
       if (match) {
         args.frame.headers.subscription = sub.id;
         args.frame.command = "MESSAGE";
@@ -163,7 +151,32 @@ var StompServer = function (config) {
         }
       }
     }
-  }
+  };
+
+  /**
+   * Test if the input subscriber has subscribed to the target destination.
+   *
+   * @param sub the subscriber
+   * @param args onSend args
+   * @returns {boolean} true if the input subscription matches destination
+   * @private
+   */
+  this._checkSubMatchDest = function (sub, args) {
+    var match = true;
+    //console.log(args.dest);
+    var tokens = stomp.StompUtils.tokenizeDestination(args.dest);
+    for (var t in tokens) {
+      var token = tokens[t];
+      if (sub.tokens[t] === undefined ||
+        (sub.tokens[t] !== token && sub.tokens[t] !== '*' && sub.tokens[t] !== '**')) {
+        match = false;
+        break;
+      } else if (sub.tokens[t] === "**") {
+        break;
+      }
+    }
+    return match;
+  };
 
   /**
    * Client subscribe event, emitted when client subscribe topic

--- a/stompServer.js
+++ b/stompServer.js
@@ -97,7 +97,7 @@ var StompServer = function (config) {
    * @property {string} sessionId
    * */
   this.onDisconnect = function (socket, receiptId) {
-    this.connectionClose(socket).bind(this);
+    connectionClose(socket);
     this.conf.debug("DISCONNECT", socket.sessionId);
     this.emit('disconnected', socket.sessionId);
     this.conf.debug("DISCONNECT", socket.sessionId, receiptId);
@@ -219,7 +219,6 @@ var StompServer = function (config) {
     sessionId: "self_1234"
   };
 
-
   /**
    * Subscription callback method
    *
@@ -236,6 +235,7 @@ var StompServer = function (config) {
   /** Subsribe topic
    * @param {string} topic Subscribed destination, wildcard is supported
    * @param {OnSubscribedMessageCallback=} callback Callback function
+   * @param {object} headers Optional headers, used by client to provide a subscription ID (headers.id)
    * @return {string} Subscription id, when message is received event with this id is emitted
    * @example
    * stompServer.subscribe("/test.data", function(msg, headers) {});
@@ -243,8 +243,13 @@ var StompServer = function (config) {
    * var subs_id = stompServer.subscribe("/test.data");
    * stompServer.on(subs_id, function(msg, headers) {});
    * */
-  this.subscribe = function (topic, callback) {
-    var id = "self_" + Math.floor(Math.random() * 99999999999);
+  this.subscribe = function (topic, callback, headers) {
+    var id;
+    if (!headers || !headers.id) {
+      id = "self_" + Math.floor(Math.random() * 99999999999);
+    } else {
+      id = headers.id;
+    }
     var sub = {
       topic: topic,
       tokens: stomp.StompUtils.tokenizeDestination(topic),

--- a/stompServer.js
+++ b/stompServer.js
@@ -139,7 +139,7 @@ var StompServer = function (config) {
       if (socket.sessionId === sub.sessionId) {
         continue;
       }
-      var match = this._checkSubMatchDest(sub, args)
+      var match = this._checkSubMatchDest(sub, args);
       if (match) {
         args.frame.headers.subscription = sub.id;
         args.frame.command = "MESSAGE";

--- a/stompServer.js
+++ b/stompServer.js
@@ -21,7 +21,7 @@ var util = require('util');
  */
 var StompServer = function (config) {
   EventEmitter.call(this);
-  if (config == undefined) {
+  if (config === undefined) {
     config = {};
   }
   this.conf = {
@@ -30,7 +30,7 @@ var StompServer = function (config) {
     debug: config.debug || function (args) {
     }
   };
-  if (this.conf.server == undefined) {
+  if (this.conf.server === undefined) {
     throw "Server is required";
   }
 
@@ -44,16 +44,6 @@ var StompServer = function (config) {
     path: this.conf.path,
     perMessageDeflate: false
   });
-
-  /**
-   * Client error event
-   * @event StompServer#error
-   * @type {object}
-   * */
-  this.socket.on('error', function (err) {
-    this.conf.debug(err);
-    this.emit('error', err);
-  }.bind(this));
 
   /**
    * Client connecting event, emitted after socket is opened.
@@ -119,8 +109,8 @@ var StompServer = function (config) {
       'message-id': stomp.genId("msg"),
       'content-type': 'text/plain'
     };
-    if (frame.body != undefined) {
-      if (typeof frame.body != 'string')
+    if (frame.body !== undefined) {
+      if (typeof frame.body !== 'string')
         throw "Message body is not string";
       frame.headers["content-length"] = frame.body.length;
     }
@@ -133,7 +123,7 @@ var StompServer = function (config) {
     this.emit('send', {frame: {headers: frame.headers, body: bodyObj}, dest: args.dest});
     for (var i in this.subscribes) {
       var sub = this.subscribes[i];
-      if (socket.sessionId == sub.sessionId) {
+      if (socket.sessionId === sub.sessionId) {
         continue;
       }
       //console.log(args.dest);
@@ -141,11 +131,11 @@ var StompServer = function (config) {
       var match = true;
       for (var t in tokens) {
         var token = tokens[t];
-        if (sub.tokens[t] == undefined ||
-          (sub.tokens[t] != token && sub.tokens[t] != '*' && sub.tokens[t] != '**')) {
+        if (sub.tokens[t] === undefined ||
+          (sub.tokens[t] !== token && sub.tokens[t] !== '*' && sub.tokens[t] !== '**')) {
           match = false;
           break;
-        } else if (sub.tokens[t] == "**") {
+        } else if (sub.tokens[t] === "**") {
           break;
         }
       }
@@ -153,7 +143,7 @@ var StompServer = function (config) {
         frame.headers.subscription = sub.id;
         frame.command = "MESSAGE";
         var sock = sub.socket;
-        if (sock != undefined) {
+        if (sock !== undefined) {
           stomp.StompUtils.sendFrame(sock, frame);
         } else {
           this.emit(sub.id, bodyObj, frame.headers);
@@ -203,7 +193,7 @@ var StompServer = function (config) {
   this.onUnsubscribe = function (socket, subId) {
     for (var t in this.subscribes) {
       var sub = this.subscribes[t];
-      if (sub.id == subId && sub.sessionId == socket.sessionId) {
+      if (sub.id === subId && sub.sessionId === socket.sessionId) {
         delete this.subscribes[t];
         this.emit("unsubscribe", sub);
         return true;
@@ -301,7 +291,7 @@ var StompServer = function (config) {
     var self = this;
     for (var t in self.subscribes) {
       var sub = self.subscribes[t];
-      if (sub.sessionId == socket.sessionId) {
+      if (sub.sessionId === socket.sessionId) {
         delete self.subscribes[t];
       }
     }
@@ -317,8 +307,8 @@ var StompServer = function (config) {
    * @return {MsgFrame} modified frame
    * */
   this.frameSerializer = function (frame) {
-    if (frame.body != undefined && frame.headers['content-type'] == 'application/json') {
-      frame.body = JSON.stringify(frame.body)
+    if (frame.body !== undefined && frame.headers['content-type'] === 'application/json') {
+      frame.body = JSON.stringify(frame.body);
     }
     return frame;
   };
@@ -328,7 +318,7 @@ var StompServer = function (config) {
    * @return {MsgFrame} modified frame
    * */
   this.frameParser = function (frame) {
-    if (frame.body != undefined && frame.headers['content-type'] == 'application/json') {
+    if (frame.body !== undefined && frame.headers['content-type'] === 'application/json') {
       frame.body = JSON.parse(frame.body);
     }
     return frame

--- a/stompServer.js
+++ b/stompServer.js
@@ -120,7 +120,7 @@ var StompServer = function (config) {
     }
     args.frame = frame;
     this.emit('send', {frame: {headers: frame.headers, body: bodyObj}, dest: args.dest});
-    this._sendToSubscriptions(socket, frame);
+    this._sendToSubscriptions(socket, args);
     if (callback) {
       callback(true);
     }
@@ -130,10 +130,10 @@ var StompServer = function (config) {
    * Send message to matching subscribers.
    *
    * @param {object} websocket to send the message on
-   * @param {string} frame message frame
+   * @param {string} args onSend args
    * @private
    */
-  this._sendToSubscriptions = function (socket, frame) {
+  this._sendToSubscriptions = function (socket, args) {
     for (var i in this.subscribes) {
       var sub = this.subscribes[i];
       if (socket.sessionId === sub.sessionId) {
@@ -153,13 +153,13 @@ var StompServer = function (config) {
         }
       }
       if (match) {
-        frame.headers.subscription = sub.id;
-        frame.command = "MESSAGE";
+        args.frame.headers.subscription = sub.id;
+        args.frame.command = "MESSAGE";
         var sock = sub.socket;
         if (sock !== undefined) {
-          stomp.StompUtils.sendFrame(sock, frame);
+          stomp.StompUtils.sendFrame(sock, args.frame);
         } else {
-          this.emit(sub.id, bodyObj, frame.headers);
+          this.emit(sub.id, bodyObj, args.frame.headers);
         }
       }
     }

--- a/test/test.js
+++ b/test/test.js
@@ -23,13 +23,23 @@ testCase('StompServer', function() {
 
   testCase('#send', function() {
     assertions('check msg and topic subscription', function() {
+      var headers = {'id': 'sub-0'};
       stompServer.subscribe("/**", function(msg, headers) {
         var topic = headers.destination;
         assert.equal(topic, '/data');
         assert.equal(msg, 'test body');
-      });
+      }, headers);
       stompServer.send('/data', {}, 'test body');
     });
   });
-});
 
+  testCase('#unsubscribe', function() {
+    assertions('check topic unsubscribe', function() {
+      var headers = {'id': 'sub-0'};
+      stompServer.subscribe("/**", function(msg, headers) {
+        var subId = headers.subscription;
+        assert.isTrue(stompServer.unsubscribe(subId), 'unsubscribe successfull, subId: ' + subId);
+      }, headers);
+    });
+  });
+});


### PR DESCRIPTION
I have been experimenting with your library to replace a Spring based stomp/websocket implementation.  On the client I have a React app using webstomp-client.  I was having a couple problems with "unsubscribe" and "disconnect".

Proposed Changes:

1. Needed a way to push a subscription ID from the client.  Changed `StompServer.subscribe()` to accept an additional `headers` argument so the client can pass an `id` to carry the subscription ID. When this is blank it uses the existing random generation for `id`. 

1. Disconnection by the client was causing my test driver server to crash.  Added check to `stomp.js::parseHeaders()` to test if `header[]` had the second entry before trimming.  This was failing when the client passed in an empty headers object.  Changed the calling signature to `connectionClose()` in `stompServer.onDisconnect()` otherwise function was not found.

1. Added unsubscribe test and README changes.

@4ib3r thanks for your StompBrokerJS, it has been very helpful for me.  I want to create a simulator to mock our websocket servers and this looks to be a great option.

Rob