### PR TITLE
Option to use binary frame as well

### DIFF
--- a/lib/stomp.js
+++ b/lib/stomp.js
@@ -18,7 +18,11 @@ function sendFrame(socket, _frame) {
   } else {
     frame_str = _frame.toString();
   }
-  socket.send(frame_str);
+  if (typeof _frame.body === 'object' && _frame.body instanceof Buffer) {
+    socket.send(frame_str, { binary: true });
+  } else {
+    socket.send(frame_str);
+  }
   return true;
 }
 

--- a/stompServer.js
+++ b/stompServer.js
@@ -109,7 +109,9 @@ var StompServer = function (config) {
       'content-type': 'text/plain'
     };
     if (frame.body !== undefined) {
-      if (typeof frame.body !== 'string')
+      if (typeof frame.body !== 'string' &&
+        !(typeof frame.body === 'object' && frame.body instanceof Buffer)
+      )
         throw "Message body is not string";
       frame.headers["content-length"] = frame.body.length;
     }


### PR DESCRIPTION
Changes proposed in this pull request:
- Allow to use `Buffer` as type of data.
- Option to use binary frame (already available in [ws](https://github.com/websockets/ws) module) for binary data.

@4ib3r please take a look.