### PR TITLE
Fix encoding binary frames

### DIFF
--- a/lib/frame.js
+++ b/lib/frame.js
@@ -1,5 +1,14 @@
 Bytes = require('./bytes');
 
+function mkBuffer(headers, body) {
+  var hBuf = new Buffer.from(headers);
+  var buf = new Buffer(hBuf.length + body.length + 1);
+  hBuf.copy(buf);
+  body.copy(buf, hBuf.length);
+  buf[buf.length - 1] = Bytes.NULL;
+  return buf;
+}
+
 function Frame(args) {
   this.command = null;
   this.headers = null;
@@ -29,7 +38,7 @@ function Frame(args) {
     this.buildFrame(args);
   }
 
-  this.toString = function () {
+  this.toStringOrBuffer = function () {
     var header_strs = [],
       frame = '';
 
@@ -40,6 +49,10 @@ function Frame(args) {
     frame += this.command + "\n";
     frame += header_strs.join("\n");
     frame += "\n\n";
+
+    if (Buffer.isBuffer(this.body)) {
+      return mkBuffer(frame, this.body);
+    }
 
     if (this.body) {
       frame += this.body;

--- a/lib/stomp-utils.js
+++ b/lib/stomp-utils.js
@@ -17,14 +17,7 @@ function sendFrame(socket, _frame) {
     });
   }
 
-  if (typeof frame.body === 'object' && frame.body instanceof Buffer) {
-    socket.send(frame.body, {
-      binary: true
-    });
-  } else {
-    var frame_str = frame.toString();
-    socket.send(frame_str);
-  }
+  socket.send(frame.toStringOrBuffer());
   return true;
 }
 

--- a/stompServer.js
+++ b/stompServer.js
@@ -139,7 +139,7 @@ var StompServer = function (config) {
     };
 
     if (frame.body !== undefined) {
-      if (typeof frame.body !== 'string' && !(typeof frame.body === 'object' && frame.body instanceof Buffer)) {
+      if (typeof frame.body !== 'string' && !Buffer.isBuffer(frame.body)) {
         throw 'Message body is not string';
       }
       frame.headers['content-length'] = frame.body.length;
@@ -356,7 +356,7 @@ var StompServer = function (config) {
    * @return {MsgFrame} modified frame
    * */
   this.frameSerializer = function (frame) {
-    if (frame.body !== undefined && frame.headers['content-type'] === 'application/json') {
+    if (frame.body !== undefined && frame.headers['content-type'] === 'application/json' && !Buffer.isBuffer(frame.body)) {
       frame.body = JSON.stringify(frame.body);
     }
     return frame;


### PR DESCRIPTION
Current implementation is sending only binary body, without headers. I am proposing a change, that creates binary frame content with headers.

When working on this, I have noticed that stompServer will try to run `JSON.stringify` on `frame.body`, even if it is already a Buffer with serialised JSON. This PR also includes a change that prevents that.