### PR TITLE
Fixing iterating over subscribes array

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stomp-broker-js",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Simple STOMP 1.1 Broker for nodejs http applications.",
   "main": "stompServer.js",
   "scripts": {

--- a/stompServer.js
+++ b/stompServer.js
@@ -252,10 +252,10 @@ var StompServer = function (config) {
    * @return {boolean}
    */
   this.onUnsubscribe = withMiddleware('unsubscribe', function (socket, subId) {
-    for (var t in this.subscribes) {
-      var sub = this.subscribes[t];
+    for (var i = 0; i < this.subscribes.length; i++) {
+      var sub = this.subscribes[i];
       if (sub.id === subId && sub.sessionId === socket.sessionId) {
-        delete this.subscribes[t];
+        this.subscribes.splice(i--, 1);
         this.emit('unsubscribe', sub);
         return true;
       }
@@ -345,7 +345,7 @@ var StompServer = function (config) {
    * @private
    */
   this._sendToSubscriptions = function (socket, args) {
-    for (var i in this.subscribes) {
+    for (var i = 0; i < this.subscribes.length; i++) {
       var sub = this.subscribes[i];
       if (socket.sessionId === sub.sessionId) {
         continue;
@@ -510,10 +510,10 @@ var StompServer = function (config) {
    */
   this.afterConnectionClose = function (socket) {
     // remove from subscribes
-    for (var t in this.subscribes) {
-      var sub = this.subscribes[t];
+    for (var i = 0; i < this.subscribes.length; i++) {
+      var sub = this.subscribes[i];
       if (sub.sessionId === socket.sessionId) {
-        delete this.subscribes[t];
+        this.subscribes.splice(i--, 1);
       }
     }
 


### PR DESCRIPTION
`for in` should be used when iterating over keys of some object. I'm fixing this because server was crashing when I had own Array.prototype methods. Other option to iterate over array is `for of` but it would not work, becasue you need to be able to use `delete`. Below patch fixed my issues.