### PR TITLE
Add support for protocol-specific configuration options

### DIFF
--- a/docs/stompServer.js.html
+++ b/docs/stompServer.js.html
@@ -59,6 +59,8 @@ var buildConfig     = require('./lib/config');
  * @param {array} [heartbeat=[10000, 10000]] Heartbeat; read documentation to config according to your desire
  * @param {number} [heartbeatErrorMargin=1000] Heartbeat error margin; specify how strict server should be
  * @param {function} [debug=function(args) {}] Debug function
+ * @param {string} [protocol=ws] Protocol to use ('sockjs' or 'ws')
+ * @param {object} [protocolConfig={}] Protocol specific configuration
  */
 
 /**
@@ -89,6 +91,7 @@ var StompServer = function (config) {
   this.frameHandler = new stomp.FrameHandler(this);
 
   this.socket = new protocolAdapter[this.conf.protocol]({
+      ...this.conf.protocolConfig,
       server: this.conf.server,
       path: this.conf.path,
       perMessageDeflate: false

--- a/lib/config.js
+++ b/lib/config.js
@@ -8,7 +8,8 @@ module.exports = function buildConfig(config) {
         heartbeat: config.heartbeat || [0, 0],
         heartbeatErrorMargin: config.heartbeatErrorMargin || 1000,
         debug: config.debug || function () {},
-        protocol: config.protocol || 'ws'
+        protocol: config.protocol || 'ws',
+        protocolConfig: config.protocolConfig || {}
     };
 
     if (conf.server === undefined) {

--- a/stompServer.js
+++ b/stompServer.js
@@ -48,6 +48,7 @@ var StompServer = function (config) {
   this.frameHandler = new stomp.FrameHandler(this);
 
   this.socket = new protocolAdapter[this.conf.protocol]({
+      ...this.conf.protocolConfig,
       server: this.conf.server,
       path: this.conf.path,
       perMessageDeflate: false


### PR DESCRIPTION
Firstly thanks for the great work with the library! It's coming in handy in the project I work on.

One annoyance I encountered is that there is no way to specify protocol adapter options. SockJS, for example, logs all requests in the console and the only way to disable that is to pass the `log` property as an empty function to SockJS constructor. As it stands, there is no way of doing it so I've made the changes in this pull request adding support for a new broker configuration key `protocolConfig`.

This option allows defining adapter specific configuration, which subsequently gets merged into the constructor parameters. With this disabling logging in the SockJS adapter becomes as easy as this:

```js
const stompServer = new StompServer({
  // ...
  protocol: 'sockjs',
  protocolConfig: {
    log: () => null,
  },
});
```